### PR TITLE
Update advisory DB & fail on warn

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -254,6 +254,8 @@ CommitMsg:
 PreCommit:
   BundleAudit:
     enabled: true
+    flags: ['--update']
+    on_warn: fail
 
   BundleCheck:
     enabled: true


### PR DESCRIPTION
The advisory DB is stale if we don't update it explicitly. This change adds about a second of overhead to the pre-commit phase: 

```
bundler-audit check --update  0.30s user 0.11s system 33% cpu 1.229 total
bundler-audit check  0.24s user 0.08s system 93% cpu 0.344 total
```