### PR TITLE
Add pull request template and default code reviewers file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# For more info about the file read https://help.github.com/en/articles/about-code-owners
+
+* @d4be4st @melcha @nikone

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Task: [#__TASK_NUMBER__](__ADD_URL_TO_PRODUCTIVE_TASK__)
+
+#### Aim
+
+
+#### Solution
+

--- a/template.rb
+++ b/template.rb
@@ -291,6 +291,30 @@ HEREDOC
 
 append_file '.gitignore', GITIGNORED_FILES
 
+# .github/PULL_REQUEST_TEMPLATE.md
+PULL_REQUEST_TEMPLATE_FILE = <<-HEREDOC.strip_heredoc
+Task: [#__TASK_NUMBER__](__ADD_URL_TO_PRODUCTIVE_TASK__)
+
+#### Aim
+
+
+#### Solution
+
+
+HEREDOC
+
+create_file '.github/PULL_REQUEST_TEMPLATE.md', PULL_REQUEST_TEMPLATE_FILE
+
+# .github/CODEOWNERS
+CODEOWNERS_FILE = <<-HEREDOC.strip_heredoc
+# For more info about the file read https://help.github.com/en/articles/about-code-owners
+
+# Set default PR reviewers. For example:
+# * @d4be4st @melcha @nikone
+HEREDOC
+
+create_file '.github/CODEOWNERS', CODEOWNERS_FILE
+
 # Ignore rubocop warnings in db/seeds.rb
 SEEDS_DISABLE_IGNORE = <<-HEREDOC.strip_heredoc
 # rubocop:disable Metrics/LineLength

--- a/template.rb
+++ b/template.rb
@@ -352,6 +352,14 @@ if yes?('Install spring? [No]', :green)
   run 'bundle exec spring binstub --all'
 end
 
+## Ask about default PR reviewers
+default_reviewers = ask('Who are default pull request reviewers (defined in .github/CODEOWNERS)? E.g.: @d4be4st @melcha @nikone. Default reviewers:', :green)
+append_to_file '.github/CODEOWNERS' do
+  <<~HEREDOC
+  * #{default_reviewers}
+  HEREDOC
+end
+
 ## Initialize git
 git :init
 


### PR DESCRIPTION
Task: [#148](https://app.productive.io/1-infinum/m/task/480553)

#### Aim
1.  Github allows us to set a [default pull request template](https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository) to a repo. We want to encourage a developer to answer specific questions in the PR description.

2.  It's a bit tedious to add the same reviewers to a PR over and over again. Github allows us to set a [list of default PR reviewers](https://help.github.com/en/articles/about-code-owners).

#### Solution
1.  Add a `.github/PULL_REQUEST_TEMPLATE.md` file. With a default template, a PR description will be automatically populated with a blank structure defined in a template.

2.  Ask a developer to specify who are going to be default PR reviewers when command `rails new`  is executed. Add the provided reviewers in the `.github/CODEOWNERS` file.