### PR TITLE
Fix Rubocop warnings for a new rails project

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -291,6 +291,19 @@ HEREDOC
 
 append_file '.gitignore', GITIGNORED_FILES
 
+# Ignore rubocop warnings in db/seeds.rb
+SEEDS_DISABLE_IGNORE = <<-HEREDOC.strip_heredoc
+# rubocop:disable Metrics/LineLength
+HEREDOC
+
+SEEDS_ENABLE_IGNORE = <<-HEREDOC.strip_heredoc
+# rubocop:enable Metrics/LineLength
+
+HEREDOC
+
+prepend_file 'db/seeds.rb', SEEDS_DISABLE_IGNORE
+append_file 'db/seeds.rb', SEEDS_ENABLE_IGNORE
+
 # Finish
 
 # set latest ruby version as local
@@ -321,3 +334,6 @@ git :init
 ## Overcommit install and sign
 run 'overcommit --install'
 run 'overcommit --sign'
+
+# Fix default rubocop errors
+run 'bundle exec rubocop -a'


### PR DESCRIPTION
Task: [#149](https://app.productive.io/1-infinum/m/task/487456)

#### Aim
When a new rails project is created, on initial commit a bunch of Rubocop errors is raised.

#### Solution
1.  Run `bundle exec rubocop -a` command at the end of the default `rails new` template.
2.  Ignore `db/seeds.rb` Rubocop errors.