### PR TITLE
Update rubocop cop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,32 +1,31 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - rubocop-rails
 
-LineLength:
+Metrics/LineLength:
   Max: 100
 
-Documentation:
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/Documentation:
   Enabled: false
 
-FrozenStringLiteralComment:
+Style/FrozenStringLiteralComment:
   Enabled: false
 
-WordArray:
-  Enabled: false
+Style/WordArray:
+  EnforcedStyle: brackets
 
-SymbolArray:
-  Enabled: false
+Style/SymbolArray:
+  EnforcedStyle: brackets
 
 Rails:
   Enabled: true
 
 RSpec/ExampleLength:
   Max: 10
-
-Style/MutableConstant:
-  Enabled: false
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
 
 AllCops:
   Exclude:

--- a/template.rb
+++ b/template.rb
@@ -176,7 +176,8 @@ append_to_file 'Gemfile', after: "group :development do\n" do
   gem 'mina-infinum', require: false
   gem 'overcommit', require: false
   gem 'rubocop', require: false
-  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec', require: false  
+  gem 'rubocop-rails', require: false
   gem 'secrets_cli', require: false
   HEREDOC
 end


### PR DESCRIPTION
#### Aim
Update rubocop cop rules.

#### Solution
- added rubocop-rails gem and require rubocop-rails cops (https://github.com/rubocop-hq/rubocop/issues/5976)
- added departments for all cops (https://github.com/rubocop-hq/rubocop/pull/7385)
- changed word and symbol arrays cops from disabled to enforcing style brackets, forcing us to using a consistent style across the app instead of letting us use both. 
- removed disabling of mutable constants cop, constants should be constant 🤓
