### PR TITLE
Use secrets_cli from gemfile

### DIFF
--- a/mina_deploy.rb
+++ b/mina_deploy.rb
@@ -32,7 +32,7 @@ task :deploy do
     invoke :'git:clone'
     invoke :'deploy:link_shared_paths'
     invoke :'bundle:install'
-    command "bundle exec secrets pull -e #{fetch(:secrets_env)} -y"
+    invoke :'secrets:pull'
     invoke :'rails:db_migrate'
     invoke :'rails:assets_precompile'
     invoke :'deploy:cleanup'

--- a/mina_deploy.rb
+++ b/mina_deploy.rb
@@ -13,6 +13,7 @@ task :staging do
   set :deploy_to, '/home/$USERNAME/www/...'
   set :user, '$USERNAME'
   set :rails_env, 'staging'
+  set :secrets_env, 'staging'
   set :branch, 'staging'
 end
 
@@ -21,17 +22,17 @@ task :production do
   set :deploy_to, '/home/$USERNAME/www/...'
   set :user, '$USERNAME'
   set :rails_env, 'production'
+  set :secrets_env, 'production'
   set :branch, 'master'
-
 end
 
 task :deploy do
   invoke :'git:ensure_pushed'
   deploy do
     invoke :'git:clone'
-    invoke :'secrets:pull'
     invoke :'deploy:link_shared_paths'
     invoke :'bundle:install'
+    command "bundle exec secrets pull -e #{fetch(:secrets_env)} -y"
     invoke :'rails:db_migrate'
     invoke :'rails:assets_precompile'
     invoke :'deploy:cleanup'

--- a/template.rb
+++ b/template.rb
@@ -94,7 +94,7 @@ BIN_SETUP = <<-HEREDOC.strip_heredoc
     system 'overcommit --install'
 
     puts '== Pulling secrets =='
-    system 'secrets pull'
+    system 'bundle exec secrets pull'
 
     puts '== Preparing database =='
     system 'bin/rake db:setup'
@@ -124,7 +124,7 @@ BIN_UPDATE = <<-HEREDOC.strip_heredoc
     # system 'npm run build'
 
     puts '== Pulling secrets =='
-    system 'secrets pull'
+    system 'bundle exec secrets pull'
 
     puts '== Preparing database =='
     system 'bin/rake db:migrate'
@@ -155,6 +155,7 @@ append_to_file 'Gemfile', after: /gem 'rails'.*\n/ do
     gem 'bugsnag'
     gem 'figaro'
     gem 'pry-rails'
+    gem 'secrets_cli', require: false
   HEREDOC
 end
 
@@ -179,7 +180,6 @@ append_to_file 'Gemfile', after: "group :development do\n" do
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
   gem 'rubocop-rails', require: false
-  gem 'secrets_cli', require: false
   HEREDOC
 end
 


### PR DESCRIPTION
#### Aim
Use secrets_cli from the Gemfile for all secrets handling during build and deployment, so we don't need to manually install secrets_cli gem on the server for each ruby version, and so we all use same secrets_cli version per project.

#### Solution
I updated the deploy script and moved secrets_cli outside of the development group in the Gemfile.
