### PR TITLE
Fix rails install with spring

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -358,6 +358,7 @@ if yes?('Install spring? [No]', :green)
     gem 'spring-commands-rspec'
     HEREDOC
   end
+  run 'bundle install'
   run 'bundle exec spring binstub --all'
 end
 


### PR DESCRIPTION
Task: NA

#### Problem
If selecting yes to spring installation while initializing a new rails app from template, the `bundle exec spring binstub -all` fails as the `spring-commands-rspec` gem is missing.

#### Solution
Re-run `bundle install` after inserting `spring-commands-rspec`
