### PR TITLE
Fix service manager deploy configuration

### DIFF
--- a/mina_deploy.rb
+++ b/mina_deploy.rb
@@ -5,7 +5,7 @@ require 'mina/infinum'
 
 set :application_name, 'awesome_app'
 set :repository, 'git://...'
-set :system_manager, :systemd
+set :service_manager, :systemd
 # set :background_worker, 'dj' / 'sidekiq'
 
 task :staging do


### PR DESCRIPTION


Task: N/A

#### Aim
Rectify service manager deploy configuration

#### Solution
Mina is expecting a variable named 'service_manager'
https://github.com/infinum/mina-infinum/blob/26544d66eda99f64914ab87ff2a6b036dd34cc4e/lib/mina/infinum/helpers.rb#L6
The previous configuration resulted in the wrong branching path being executed.
