### PR TITLE
Add rubocop binstubs and move to development group

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -353,9 +353,10 @@ run 'bundle exec rails generate rspec:install'
 
 ## Initialize spring
 if yes?('Install spring? [No]', :green)
-  append_to_file 'Gemfile', after: "group :development, :test do\n" do
+  append_to_file 'Gemfile', after: "group :development do\n" do
     <<-HEREDOC
     gem 'spring-commands-rspec'
+    gem 'spring-commands-rubocop'
     HEREDOC
   end
   run 'bundle install'


### PR DESCRIPTION
Task: NA

#### Aim
Spring binstubs are used only in the development enviroment so the additional binstub gems should be moved to the development group only.

