### PR TITLE
Enable new rubocop cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,15 @@ Style/WordArray:
 
 Style/SymbolArray:
   EnforcedStyle: brackets
+  
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
 
 Rails:
   Enabled: true


### PR DESCRIPTION
Task: NA

#### Aim
Explicitly enabled new cops added with [v0.80.0](https://github.com/rubocop-hq/rubocop/releases/tag/v0.80.0)


