### PR TITLE
Enable new rubocop cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,4 @@ AllCops:
     - 'db/schema.rb'
     - 'db/migrate/*.rb'
     - 'config/**/*.rb'
+  NewCops: enable


### PR DESCRIPTION
New rubocop versions add new cops in pending state, which causes warnings when running rubocop, and errors when running overcommit.

```
➜  zeitwerk_app git:(master) ✗ rubocop app
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/ExponentialNotation (0.82)
```

It’s required now to explicitly enable or disable all new cops.
To keep the old behavior, we can use:
```
AllCops:
  NewCops: enable
```

Reasoning:
> In the early versions of RuboCop a common source of frustration was that new cops were added to pretty much every release, and as they were enabled by default, every upgrade resulted in broken CI builds and trying to figure out what exactly was changed. After considering many options to address this eventually we opted for an approach that limits these type of changes to major RuboCop releases.
> Now new cops introduced between major versions are set to a special pending status and are not enabled by default. A warning is emitted if such cops are not explicitly enabled or disabled in the user configuration.

Read more about this here https://docs.rubocop.org/en/latest/versioning/#pending-cops

@infinum/backend-team 