### PR TITLE
Set gemfile in overcommit.yml

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -248,6 +248,8 @@ create_file 'config/deploy.rb', Net::HTTP.get(URI(MINA_DEPLOY_URL))
 
 # Overcommit
 OVERCOMMIT_YML_FILE = <<-HEREDOC.strip_heredoc
+gemfile: Gemfile
+
 CommitMsg:
   HardTabs:
     enabled: true


### PR DESCRIPTION
#### Aim
The version of `overcommit` gem that is run before a commit is the newest version installed on a system (for a given version of ruby, of course). As [documentation](https://github.com/sds/overcommit#dependencies) suggests, when using bundler to manage ruby versions, we should set `gemfile` key. This way all hooks will be run with gem versions from Gemfile.lock.

#### Solution
Explicitly define `gemfile` key in `overcommit.yml`.
