### PR TITLE
[#9] generate the annotate rake tasks

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -418,6 +418,16 @@ append_to_file '.github/CODEOWNERS' do
   HEREDOC
 end
 
+# add annotate task file and ignore its rubocop violations
+run 'bundle exec rails generate annotate:install'
+ANNOTATE_TASK_FILE = 'lib/tasks/auto_annotate_models.rake'
+prepend_file ANNOTATE_TASK_FILE, "# frozen_string_literal: true\n\n"
+append_to_file ANNOTATE_TASK_FILE, after: "its thing in production.\n" do
+  "# rubocop:disable Metrics/BlockLength, Rails/RakeEnvironment\n"
+end
+append_file ANNOTATE_TASK_FILE,
+            "# rubocop:enable Metrics/BlockLength, Rails/RakeEnvironment\n"
+
 ## Initialize git
 git :init
 


### PR DESCRIPTION
Task: [#9](https://app.productive.io/1-infinum/projects/129082/tasks/task/1655558)

#### Aim

Generate the Annotate gem's rake tasks when creating a new Rails app.

#### Solution

Added the necessary generation code to the `template.rb`. Fixed #56.