### PR TITLE
Add mina setup to deploy steps

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -196,7 +196,7 @@ BIN_DEPLOY = <<~HEREDOC.strip_heredoc
   time bundle install
 
   echo "=========== mina deploy =============="
-  time bundle exec mina $environment ssh_keyscan_domain deploy
+  time bundle exec mina $environment ssh_keyscan_domain setup deploy
 
   #############################################
   # Uncomment this if you need to publish dox #
@@ -283,7 +283,7 @@ end
 append_to_file 'Gemfile' do
   <<-HEREDOC.strip_heredoc
 
-    group :test do 
+    group :test do
       gem 'rspec-rails'
     end
   HEREDOC


### PR DESCRIPTION
Task: No task

#### Aim
Add mina setup task to deploy steps. It needs to be run when you're editing shared_dirs and shared_files in deploy.rb 
https://github.com/mina-deploy/mina/blob/master/docs/getting_started.md#step-4-considerations-after-first-deploy

Running it doesn't take much time. Example from RGO: 

> Elapsed time: 1.63 seconds

#### Solution
Add mina setup task to deploy steps

