### PR TITLE
Add yarn install to build steps

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -162,6 +162,13 @@ BIN_BUILD = <<~HEREDOC.strip_heredoc
   echo "=========== bundle audit ==========="
   time bundle exec bundle-audit check --update --quiet
 
+  #############################################
+  # Uncomment this if you yarn libraries for  #
+  # running your tests                        #
+  #############################################
+  # echo "=========== yarn install ==========="
+  # time yarn install
+
   echo "=========== zeitwerk check ==========="
   time bundle exec rails zeitwerk:check
 
@@ -283,7 +290,7 @@ end
 append_to_file 'Gemfile' do
   <<-HEREDOC.strip_heredoc
 
-    group :test do 
+    group :test do
       gem 'rspec-rails'
     end
   HEREDOC

--- a/template.rb
+++ b/template.rb
@@ -163,8 +163,8 @@ BIN_BUILD = <<~HEREDOC.strip_heredoc
   time bundle exec bundle-audit check --update --quiet
 
   #############################################
-  # Uncomment this if you yarn libraries for  #
-  # running your tests                        #
+  # Uncomment this if you need yarn libraries #
+  # for running your tests                    #
   #############################################
   # echo "=========== yarn install ==========="
   # time yarn install


### PR DESCRIPTION
Task: No task

#### Aim
We sometimes need yarn libs for running tests. Therefore, we should add it to build steps.

#### Solution
Added yarn install to build steps with a comment when to enable this step.
