### PR TITLE
Rename rubocop-infinum configuration yml file reference

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_gem:
-  rubocop-infinum: .infinum.yml
+  rubocop-infinum: rubocop.yml
 
 require: rubocop-infinum

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_gem:
-  rubocop-infinum: .rubocop.yml
+  rubocop-infinum: .infinum.yml
 
 require: rubocop-infinum

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `-m` flag tells the generator to run our app [template](https://github.com/i
 - Initializes spring binstubs
 - Updates the secrets.yml file to use Figaro and have defaults
 - Creates a `config/application.yml` file for Figaro
-- Creates a `.rubocop.yml` file with our defaults
+- Creates a `.infinum.yml` file with our RuboCop defaults
 - Git inits
 - Adds more common gitignored files to `.gitignore`
 - Adds documentation in `docs` folders

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `-m` flag tells the generator to run our app [template](https://github.com/i
 - Initializes spring binstubs
 - Updates the secrets.yml file to use Figaro and have defaults
 - Creates a `config/application.yml` file for Figaro
-- Creates a `.infinum.yml` file with our RuboCop defaults
+- Creates a `.rubocop.yml` file with our defaults
 - Git inits
 - Adds more common gitignored files to `.gitignore`
 - Adds documentation in `docs` folders


### PR DESCRIPTION
Task: -

#### Aim

All projects that use rubocop-infinum have issues with using the configuration from the gem.

#### Solution

Rename the configuration yml file in the gem. This PR just updates the references.