### PR TITLE
Fix references to docs files

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -41,7 +41,7 @@ create_file 'README.md', README_MD, force: true
 # Technical documentation
 [
   'docs/README.md',
-  'docs/architecture.md'
+  'docs/architecture.md',
   'docs/development_workflow.md'
 ].each do |filename|
   get("#{BASE_URL}/#{filename}", filename)


### PR DESCRIPTION
Task: no_task

#### Aim
default_rails_template didn't work correctly because all documentation files were referenced in a template

#### Solution
Removed documentation files and added new ones to the template
