### PR TITLE
Show bundle-audit check output

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -157,7 +157,8 @@ BIN_BUILD = <<~HEREDOC.strip_heredoc
   time bundle exec rails db:test:prepare
 
   echo "=========== bundle audit ==========="
-  time bundle exec bundle-audit check --update --quiet
+  time bundle exec bundle-audit update --quiet
+  time bundle exec bundle-audit check
 
   #############################################
   # Uncomment this if you need yarn libraries #


### PR DESCRIPTION
No task

#### Aim

In https://github.com/infinum/default_rails_template/pull/70 we removed all logging from the `bundle-audit check --update` command with the `--quiet` flag because the `--update` flag added logs which cluttered the output. Unfortunately, it also removed `check` command logs which tell you if advisories have been found. Those logs were useful because without them you can't know why the command failed, making build debugging harder.


#### Solution

Separate `bundle-audit` command into two steps:
1. `bundle-audit update --quiet` - updates the advisory DB but doesn't output anything
2. `bundle-audit check` - checks for advisories and outputs the result