### PR TITLE
Add revisor badges to readme

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -3,6 +3,9 @@ BASE_URL = 'https://raw.githubusercontent.com/infinum/default_rails_template/mas
 # Readme.md
 README_MD = <<-HEREDOC.strip_heredoc
 [![Build Status](https://docs.semaphoreci.com/essentials/status-badges/)](https://semaphoreci.com/infinum/APP)
+![Health score](https://revisor.infinum.com/api/v1/badges/add-project-key?type=health_score)
+![CVE count](https://revisor.infinum.com/api/v1/badges/add-project-key?type=cve_count)
+
 # README
 
 ## [Technical Documentation](docs/README.md)


### PR DESCRIPTION
Task: No task

#### Aim
We added Revisor badges for health score and CVE count to all our projects so it makes sense to add it to our default template as well

#### Solution
Add Revisor badges for health score and CVE count to readme
