### PR TITLE
Remove github links from changelog template

### DIFF
--- a/GEM_CHANGELOG_TEMPLATE.md
+++ b/GEM_CHANGELOG_TEMPLATE.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## [v1.0.0](https://github.com/infinum/some-gem/tree/v-current) (YYYY-MM-DD)
-[Full Changelog](https://github.com/infinum/some-gem/compare/v-previous...v-current)
+## v1.0.0 (YYYY-MM-DD)
 
 ### Enhancements
 


### PR DESCRIPTION
Task: No task

#### Aim
We decided to remove Github links to tree and diff for previous version because we're going to use Github releases.

#### Solution
Remove Github links from changelog template.
