### PR TITLE
Task #501 - Executable bin/build and bin/deploy scripts

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -186,6 +186,7 @@ BIN_BUILD = <<~HEREDOC.strip_heredoc
   time bundle exec rspec
 HEREDOC
 create_file 'bin/build', BIN_BUILD, force: true
+chmod 'bin/build', 0755, verbose: false
 
 BIN_DEPLOY = <<~HEREDOC.strip_heredoc
   #!/usr/bin/env bash
@@ -228,6 +229,7 @@ BIN_DEPLOY = <<~HEREDOC.strip_heredoc
   # fi
 HEREDOC
 create_file 'bin/deploy', BIN_DEPLOY, force: true
+chmod 'bin/deploy', 0755, verbose: false
 
 # bundler config
 BUNDLER_CI_BUILD_CONFIG = <<~HEREDOC.strip_heredoc


### PR DESCRIPTION
Task: [#501](https://app.productive.io/1-infinum/tasks/2159618)

#### Aim

`bin/build` and `bin/deploy` scripts generated by the template aren't executable by default.

#### Solution

Make those scripts executable by running `chmod`. I used [0755](https://chmodcommand.com/chmod-0755/). This is the same set of permissions set by Rails (see [here](https://github.com/rails/jsbundling-rails/blob/b6ec0980ff573203ac1031074e57bc59be5acbf5/lib/install/install.rb#L46) and [here](https://github.com/rails/rails/blob/52c0711bcf9bc991887822f235e8c561b53a8213/railties/lib/rails/generators/rails/plugin/plugin_generator.rb#L182)).

