### PR TITLE
Fix bundle environment variable typo

### DIFF
--- a/mina_deploy.rb
+++ b/mina_deploy.rb
@@ -33,7 +33,7 @@ task :deploy do
     invoke :'git:clone'
     invoke :'deploy:link_shared_paths'
     invoke :'bundle:install_gem'
-    command "export BUNDLER_APP_CONFIG='.bundle/server'"
+    command "export BUNDLE_APP_CONFIG='.bundle/server'"
     invoke :'bundle:install'
     command 'yarn install'
     invoke :'secrets:pull'


### PR DESCRIPTION
No task

#### Aim & Solution

Rename `BUNDLER_APP_CONFIG` environment variable to `BUNDLE_APP_CONFIG` (no R). ([docs](https://bundler.io/man/bundle-config.1.html))

Note: in other places, the variable name is correctly written, the typo only appeared here.

