### PR TITLE
Remove unnecessary rails_env from bin/deploy

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -194,7 +194,6 @@ BIN_DEPLOY = <<~HEREDOC.strip_heredoc
 
   echo "=========== setting env variables ==========="
   environment=$1
-  export RAILS_ENV='test'
   export BUNDLE_APP_CONFIG='.bundle/ci-deploy'
 
   echo "=========== install bundler ==========="


### PR DESCRIPTION
Task: n/a

Remove unnecessary **RAILS_ENV=test** from **bin/deploy** script. It's a c/p leftover from bin/build script. 
It's not needed and it's confusing, $environment variable set from the first argument is all we need.
