### PR TITLE
Fix bundler app config

### DIFF
--- a/mina_deploy.rb
+++ b/mina_deploy.rb
@@ -6,7 +6,7 @@ require 'mina/infinum'
 set :application_name, 'awesome_app'
 set :repository, 'git://...'
 set :service_manager, :systemd
-set :bundle_options, ''
+set :bundle_withouts, 'development test ci deploy'
 # set :background_worker, 'dj' / 'sidekiq'
 
 task :staging do
@@ -33,7 +33,6 @@ task :deploy do
     invoke :'git:clone'
     invoke :'deploy:link_shared_paths'
     invoke :'bundle:install_gem'
-    command "export BUNDLE_APP_CONFIG='.bundle/server'"
     invoke :'bundle:install'
     command 'yarn install'
     invoke :'secrets:pull'

--- a/template.rb
+++ b/template.rb
@@ -245,13 +245,6 @@ BUNDLER_CI_DEPLOY_CONFIG = <<~HEREDOC.strip_heredoc
 HEREDOC
 create_file '.bundle/ci-deploy/config', BUNDLER_CI_DEPLOY_CONFIG, force: true
 
-BUNDLER_SERVER_CONFIG = <<~HEREDOC.strip_heredoc
-  ---
-  BUNDLE_DEPLOYMENT: "true"
-  BUNDLE_WITHOUT: "development test ci deploy"
-HEREDOC
-create_file '.bundle/server/config', BUNDLER_SERVER_CONFIG, force: true
-
 # bugsnag
 BUGSNAG_CONFIG = <<-HEREDOC.strip_heredoc
   Bugsnag.configure do |config|


### PR DESCRIPTION
Introducing BUNDLE_APP_CONFIG to deploy broke passenger because it cant find installed gems.