### PR TITLE
Remove RAILS_ENV=test from CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,5 +105,3 @@ jobs:
         run: until docker exec postgres pg_isready; do sleep 1; done
       - name: CI steps
         run: 'parallel --lb -k -j0 ::: ${{ inputs.ci_steps }}'
-        env:
-          RAILS_ENV: test


### PR DESCRIPTION
Task: No task

#### Aim
Remove RAILS_ENV=test from CI jobs

#### Solution
Remove RAILS_ENV=test from CI jobs
