### PR TITLE
Add missing RAILS_ENV=test when preparing db for dox

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -224,7 +224,7 @@ BIN_DEPLOY = <<~HEREDOC.strip_heredoc
   #   time yarn install
 
   #   echo "=========== rails db:test:prepare ==========="
-  #   time bundle exec rails db:test:prepare
+  #   time RAILS_ENV=test bundle exec rails db:test:prepare
 
   #   echo "=========== mina dox publish ==========="
   #   time bundle exec mina $environment dox:publish


### PR DESCRIPTION
Task: No task

#### Aim
In https://github.com/infinum/default_rails_template/commit/3802732f434be784e3d8373e9b30f02b7c44dbac we removed setting `RAILS_ENV=test` at the top of the bin/deploy script. We still need it for preparing db for running dox.

#### Solution
Add explicit `RAILS_ENV=test` before `rails db:test:prepare`
