### PR TITLE
Enable triggering builds manually

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 
 jobs:
   build:


### PR DESCRIPTION
Task: No task

#### Aim
Deploys could be triggered manually from some branch, but builds couldn't.

#### Solution
Add option to trigger a build workflow:

<img width="899" alt="Screenshot 2022-01-20 at 07 43 03" src="https://user-images.githubusercontent.com/6377753/150287140-9de1c86a-4882-4034-be14-005910d94aca.png">

