### PR TITLE
Set env variables for generating dox

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,14 @@ on:
     secrets:
       SSH_PRIVATE_KEY:
         required: true
+      VAULT_ADDR:
+        required: true
+      VAULT_AUTH_METHOD:
+        required: true
+      VAULT_AUTH_ROLE_ID:
+        required: true
+      VAULT_AUTH_SECRET_ID:
+        required: true
 
 jobs:
   deploy:
@@ -60,3 +68,8 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - run: bin/deploy ${{ inputs.environment }}
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
+          VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+          VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/deploy-production.yml
+++ b/deploy-production.yml
@@ -17,3 +17,7 @@ jobs:
       deployers: 'DEPLOY USERS GO HERE' # Example: '@github_username1 @github_username2'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_PRODUCTION }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
+      VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+      VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/deploy-staging.yml
+++ b/deploy-staging.yml
@@ -17,3 +17,7 @@ jobs:
       deployers: 'DEPLOY USERS GO HERE' # Example: '@github_username1 @github_username2'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
+      VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+      VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}


### PR DESCRIPTION
Task: No task

#### Aim
Currently generating dox fails when pulling secrets because env variables are not set.
![image (13)](https://user-images.githubusercontent.com/6377753/150335868-3e9f2cc5-c89f-4955-9fcc-6f84ae57d53a.png)


#### Solution
Set env variables needed for generating dox during deploy


**This is just a proposal, there's probably a better way to do it?**
