### PR TITLE
Add a new workflow for generating API docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,14 +41,6 @@ on:
     secrets:
       SSH_PRIVATE_KEY:
         required: true
-      VAULT_ADDR:
-        required: true
-      VAULT_AUTH_METHOD:
-        required: true
-      VAULT_AUTH_ROLE_ID:
-        required: true
-      VAULT_AUTH_SECRET_ID:
-        required: true
 
 jobs:
   deploy:
@@ -68,8 +60,3 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - run: bin/deploy ${{ inputs.environment }}
-        env:
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-          VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
-          VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
-          VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,96 @@
+name: Publish docs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      # Selects the version of Postgres for running tests
+      # See: https://github.com/docker-library/docs/blob/master/postgres/README.md#supported-tags-and-respective-dockerfile-links
+      postgres_image:
+        required: true
+        type: string
+
+      # Sets BUNDLE_APP_CONFIG environment variable
+      # See: https://bundler.io/man/bundle-config.1.html
+      bundle_app_config:
+        required: false
+        type: string
+        default: .bundle/ci-deploy
+
+      # Selects the runner on which the workflow will run
+      # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      runner:
+        required: false
+        type: string
+        default: ubuntu-20.04
+
+      # Sets the Mina environment (e.g. staging, production)
+      # A task by the same name must exist in config/deploy.rb
+      environment:
+        required: true
+        type: string
+    secrets:
+      SSH_PRIVATE_KEY:
+        required: true
+      VAULT_ADDR:
+        required: true
+      VAULT_AUTH_METHOD:
+        required: true
+      VAULT_AUTH_ROLE_ID:
+        required: true
+      VAULT_AUTH_SECRET_ID:
+        required: true
+
+jobs:
+  publish_docs:
+    name: 'Publish docs'
+    runs-on: ${{ inputs.runner }}
+    env:
+      BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
+    services:
+      postgres:
+        image: postgres:${{ inputs.postgres_image }}
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --name=postgres
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.node-version'
+      - name: Prepare node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Install JS packages
+        run: yarn install --frozen-lockfile
+      - name: Prepare CI
+        run: bin/prepare_ci
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
+          VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+          VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}
+      - name: Wait for Postgres to be ready
+        run: until docker exec postgres pg_isready; do sleep 1; done
+      - name: Publish docs
+        run: 'bin/publish_docs ${{ inputs.environment }}'
+        env:
+          RAILS_ENV: test

--- a/deploy-production.yml
+++ b/deploy-production.yml
@@ -17,7 +17,3 @@ jobs:
       deployers: 'DEPLOY USERS GO HERE' # Example: '@github_username1 @github_username2'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_PRODUCTION }}
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
-      VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
-      VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/deploy-staging.yml
+++ b/deploy-staging.yml
@@ -17,7 +17,3 @@ jobs:
       deployers: 'DEPLOY USERS GO HERE' # Example: '@github_username1 @github_username2'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
-      VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
-      VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/deploy-staging.yml
+++ b/deploy-staging.yml
@@ -17,3 +17,17 @@ jobs:
       deployers: 'DEPLOY USERS GO HERE' # Example: '@github_username1 @github_username2'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
+
+  # publish_docs: # UNCOMMENT THIS IF YOU USE DOX FOR API DOCUMENTATION
+  #   name: Publish docs
+  #   needs: [deploy]
+  #   uses: infinum/default_rails_template/.github/workflows/publish-docs.yml@v1
+  #   with:
+  #     postgres_image: '13.2'
+  #     environment: staging
+  #   secrets:
+  #     SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
+  #     VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+  #     VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}
+  #     VAULT_AUTH_ROLE_ID: ${{ secrets.VAULT_AUTH_ROLE_ID }}
+  #     VAULT_AUTH_SECRET_ID: ${{ secrets.VAULT_AUTH_SECRET_ID }}

--- a/template.rb
+++ b/template.rb
@@ -211,27 +211,35 @@ BIN_DEPLOY = <<~HEREDOC.strip_heredoc
   time bundle exec mina $environment ssh_keyscan_domain
   time bundle exec mina $environment setup
   time bundle exec mina $environment deploy
+HEREDOC
+create_file 'bin/deploy', BIN_DEPLOY, force: true
+chmod 'bin/deploy', 0755, verbose: false
+
+BIN_PUBLISH_DOCS = <<~HEREDOC.strip_heredoc
+  #!/usr/bin/env bash
+
+  set -o errexit
+  set -o pipefail
+  set -o nounset
+
+  echo "=========== setting env variables ==========="
+  environment=$1
 
   #############################################
   # Uncomment this if you need to publish dox #
   # Delete not needed environment             #
   #############################################
+  #
   # if [[ $environment =~ ^(production|uat|staging)$ ]]; then
-  #   echo "=========== secrets pull =============="
-  #   time bundle exec secrets pull -e development -y
-
-  #   echo "=========== yarn install =============="
-  #   time yarn install
-
   #   echo "=========== rails db:test:prepare ==========="
-  #   time RAILS_ENV=test bundle exec rails db:test:prepare
-
+  #   time bundle exec rails db:test:prepare
+  #
   #   echo "=========== mina dox publish ==========="
   #   time bundle exec mina $environment dox:publish
   # fi
 HEREDOC
-create_file 'bin/deploy', BIN_DEPLOY, force: true
-chmod 'bin/deploy', 0755, verbose: false
+create_file 'bin/publish_docs', BIN_PUBLISH_DOCS, force: true
+chmod 'bin/publish_docs', 0755, verbose: false
 
 # get("#{BASE_URL}/build.yml", '.github/workflows/build.yml')
 # get("#{BASE_URL}/deploy-staging.yml", '.github/workflows/deploy-staging.yml')


### PR DESCRIPTION
Task: No task

#### Aim
We had a [discussion on Slack](https://infinum.slack.com/archives/C02S24Y5JSV/p1642679196001300) today about generating dox for API apps. 

It was previously done in bin/deploy but now it started failing because of:

- missing env variables for pulling secrets #106 
- missing postgres
- ...

We came to a conclusion to create a new workflow for generating dox.

#### Solution
Reverted #106 because it's not needed anymore since we're adding a new workflow. 

Added a new workflow for publishing docs that [Lovro suggested](https://gist.github.com/lovro-bikic/0f79075f413ef343650d693c27b37f3e) with a few changes:

- removed use_node option because you always need node for generating API docs with dox
- added prepare CI step for pulling secrets
- removed caching rubocop step since we don't need it
- added a new job to deploy-staging.yml workflow (commented out with instructions)

This workflow should be run on successful deploy (defined in deploy-#{env}.yml files with needs: [deploy]).

bin/deploy is also updated and we removed all dox related commands from there
bin/publish_docs now has commands for generating docs

Note: I haven't tried this workflow yet. Please leave a review with suggestions/comments if you have them.
