### PR TITLE
Add missing ssh_keyscan_domain to bin/publish_docs

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -235,6 +235,7 @@ BIN_PUBLISH_DOCS = <<~HEREDOC.strip_heredoc
   #   time bundle exec rails db:test:prepare
   #
   #   echo "=========== mina dox publish ==========="
+  #   time bundle exec mina $environment ssh_keyscan_domain
   #   time bundle exec mina $environment dox:publish
   # fi
 HEREDOC


### PR DESCRIPTION
Task: No task

#### Aim
Generating docs failed with `Host key verification failed.` because we were missing mina ssh_keyscan_domain command

#### Solution
Add missing mina ssh_keyscan_domain command
