### PR TITLE
Define branch for publishing docs job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,13 +50,17 @@ jobs:
       BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
     if: ${{ github.event_name == 'workflow_dispatch' && contains(inputs.deployers, format('@{0}', github.actor)) || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Git checkout
+        uses: actions/checkout@v2
         with:
           ref: ${{ inputs.branch }}
-      - uses: ruby/setup-ruby@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - uses: webfactory/ssh-agent@v0.5.4
+      - name: Prepare SSH agent
+        uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - run: bin/deploy ${{ inputs.environment }}
+      - name: Deploy
+        run: bin/deploy ${{ inputs.environment }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,6 +32,12 @@ on:
       environment:
         required: true
         type: string
+
+      # Sets the Git branch which will be checked out
+      branch:
+        required: true
+        type: string
+
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -61,6 +67,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/deploy-staging.yml
+++ b/deploy-staging.yml
@@ -25,6 +25,7 @@ jobs:
   #   with:
   #     postgres_image: '13.2'
   #     environment: staging
+  #     branch: staging
   #   secrets:
   #     SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY_STAGING }}
   #     VAULT_ADDR: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
Task: No task

#### Aim
We realized that master branch was used for publishing docs on all environments because a specific branch wasn't defined.

#### Solution
Define a branch for publishing docs.
Add step names for deploy workflow.
