### PR TITLE
Add support for additional environment variables in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,12 @@ on:
       VAULT_AUTH_SECRET_ID:
         required: true
 
+      # Additional environment variables set in the workflow
+      # Format: JSON object with string values (key becomes env variable name, value becomes env variable value)
+      # Example: '{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }' 
+      ADDITIONAL_VARIABLES:
+        required: false
+
 jobs:
   build:
     name: 'Build'
@@ -65,6 +71,18 @@ jobs:
           - 5432:5432
         options: --name=postgres
     steps:
+      - name: Set up additional environment variables
+        env:
+          ADDITIONAL_VARIABLES: ${{ secrets.ADDITIONAL_VARIABLES }}
+        if: ${{ env.ADDITIONAL_VARIABLES }}
+        run: >
+          if echo '${{ env.ADDITIONAL_VARIABLES }}' | jq >/dev/null 2>&1; then
+            echo '${{ env.ADDITIONAL_VARIABLES }}' | jq -r 'to_entries[] | "\(.key) \(.value)"' | \
+              while read -r key value; do echo "$key=$value" >> $GITHUB_ENV && echo "Variable $key has been set"; done
+          else
+            echo "ADDITIONAL_VARIABLES secret you supplied is not a valid JSON object. Check the formatting of the secret."
+            exit 1
+          fi
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,12 @@ on:
       SSH_PRIVATE_KEY:
         required: true
 
+      # Additional environment variables set in the workflow
+      # Format: JSON object with string values (key becomes env variable name, value becomes env variable value)
+      # Example: '{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }' 
+      ADDITIONAL_VARIABLES:
+        required: false
+
 jobs:
   deploy:
     name: Deploy
@@ -50,6 +56,18 @@ jobs:
       BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
     if: ${{ github.event_name == 'workflow_dispatch' && contains(inputs.deployers, format('@{0}', github.actor)) || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Set up additional environment variables
+        env:
+          ADDITIONAL_VARIABLES: ${{ secrets.ADDITIONAL_VARIABLES }}
+        if: ${{ env.ADDITIONAL_VARIABLES }}
+        run: >
+          if echo '${{ env.ADDITIONAL_VARIABLES }}' | jq >/dev/null 2>&1; then
+            echo '${{ env.ADDITIONAL_VARIABLES }}' | jq -r 'to_entries[] | "\(.key) \(.value)"' | \
+              while read -r key value; do echo "$key=$value" >> $GITHUB_ENV && echo "Variable $key has been set"; done
+          else
+            echo "ADDITIONAL_VARIABLES secret you supplied is not a valid JSON object. Check the formatting of the secret."
+            exit 1
+          fi
       - name: Git checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -50,6 +50,12 @@ on:
       VAULT_AUTH_SECRET_ID:
         required: true
 
+      # Additional environment variables set in the workflow
+      # Format: JSON object with string values (key becomes env variable name, value becomes env variable value)
+      # Example: '{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }' 
+      ADDITIONAL_VARIABLES:
+        required: false
+
 jobs:
   publish_docs:
     name: 'Publish docs'
@@ -65,6 +71,18 @@ jobs:
           - 5432:5432
         options: --name=postgres
     steps:
+      - name: Set up additional environment variables
+        env:
+          ADDITIONAL_VARIABLES: ${{ secrets.ADDITIONAL_VARIABLES }}
+        if: ${{ env.ADDITIONAL_VARIABLES }}
+        run: >
+          if echo '${{ env.ADDITIONAL_VARIABLES }}' | jq >/dev/null 2>&1; then
+            echo '${{ env.ADDITIONAL_VARIABLES }}' | jq -r 'to_entries[] | "\(.key) \(.value)"' | \
+              while read -r key value; do echo "$key=$value" >> $GITHUB_ENV && echo "Variable $key has been set"; done
+          else
+            echo "ADDITIONAL_VARIABLES secret you supplied is not a valid JSON object. Check the formatting of the secret."
+            exit 1
+          fi
       - name: Git checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
#### Aim

On some projects, developers need to pass additional environment variables to a workflow (e.g. `CODECOV_TOKEN`). Currently, this cannot be achieved nicely with GHA because there is no API for passing arbitrary environment variables to a reusable workflow. The only way to pass a variable is to have it defined in the reusable workflow beforehand.

This PR provides a solution which circumvents that limitation.

#### Solution

Add an optional secret `ADDITIONAL_VARIABLES` through which the developers can supply any environment variables they need. The expected structure of the secret is a JSON object, for example:
```json
{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }
```
which will be parsed by the reusable workflow using [jq](https://stedolan.github.io/jq/). Keys of the object will become environment variable names, and the values of the object will become environment variable values. In the above example, that means the following env variables would be exported: `FOO=BAR` and `BAZ=THE_SECRET_VALUE_OF_BAZ`.

The following examples show how the new secret works.

1. The secret hasn't been passed (the step is skipped):
<img width="329" alt="Screenshot 2022-02-05 at 10 47 35" src="https://user-images.githubusercontent.com/36794420/152637263-5905a5fa-0eba-40cc-81d4-4eeee62c2bea.png">

2. The secret is invalid JSON (the workflow aborts, an error message is output):
<img width="852" alt="Screenshot 2022-02-05 at 10 39 17" src="https://user-images.githubusercontent.com/36794420/152637304-d4b1dd16-62e1-4d7e-ba8d-e889c1a9ede1.png">

3. The secret is valid JSON (environment variables are set, and a success message is printed for each variable):
<img width="435" alt="Screenshot 2022-02-05 at 10 40 48" src="https://user-images.githubusercontent.com/36794420/152637331-4cf2a037-d31a-4c71-a81b-e21ef4011105.png">




