### PR TITLE
Run `bin/prepare_ci` workflow step only if the script exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Prepare CI
         run: bin/prepare_ci
+        if: hashFiles('bin/prepare_ci') != ''
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -109,6 +109,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Prepare CI
         run: bin/prepare_ci
+        if: hashFiles('bin/prepare_ci') != ''
         env:
           VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
           VAULT_AUTH_METHOD: ${{ secrets.VAULT_AUTH_METHOD }}


### PR DESCRIPTION
#### Aim

Allow skipping the `bin/prepare_ci` step in the workflow (some projects don't use it).

#### Solution

Use [hashFiles](https://docs.github.com/en/actions/learn-github-actions/expressions#hashfiles) function to check if `bin/prepare_ci` exists before executing it.

