### PR TITLE
Add node toggle to publish docs github action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,6 +27,12 @@ on:
         type: string
         default: ubuntu-20.04
 
+      # Determines whether to install Node and run `yarn install`
+      use_node:
+        required: false
+        type: boolean
+        default: true
+
       # Sets the Mina environment (e.g. staging, production)
       # A task by the same name must exist in config/deploy.rb
       environment:
@@ -93,20 +99,23 @@ jobs:
           bundler-cache: true
       - name: Set up Node
         uses: actions/setup-node@v2
+        if: ${{ inputs.use_node }}
         with:
           node-version-file: '.node-version'
       - name: Prepare node_modules cache
         uses: actions/cache@v2
+        if: ${{ inputs.use_node }}
         with:
           path: node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-modules-
+      - name: Install JS packages
+        if: ${{ inputs.use_node }}
+        run: yarn install --frozen-lockfile
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Install JS packages
-        run: yarn install --frozen-lockfile
       - name: Prepare CI
         run: bin/prepare_ci
         if: hashFiles('bin/prepare_ci') != ''

--- a/template.rb
+++ b/template.rb
@@ -225,19 +225,12 @@ BIN_PUBLISH_DOCS = <<~HEREDOC.strip_heredoc
   echo "=========== setting env variables ==========="
   environment=$1
 
-  #############################################
-  # Uncomment this if you need to publish dox #
-  # Delete not needed environment             #
-  #############################################
-  #
-  # if [[ $environment =~ ^(production|uat|staging)$ ]]; then
-  #   echo "=========== rails db:test:prepare ==========="
-  #   time bundle exec rails db:test:prepare
-  #
-  #   echo "=========== mina dox publish ==========="
-  #   time bundle exec mina $environment ssh_keyscan_domain
-  #   time bundle exec mina $environment dox:publish
-  # fi
+  echo "=========== rails db:test:prepare ==========="
+  time bundle exec rails db:test:prepare
+
+  echo "=========== mina dox publish ==========="
+  time bundle exec mina "$environment" ssh_keyscan_domain
+  time bundle exec mina "$environment" dox:publish
 HEREDOC
 create_file 'bin/publish_docs', BIN_PUBLISH_DOCS, force: true
 chmod 'bin/publish_docs', 0755, verbose: false


### PR DESCRIPTION
Task: NA

#### Aim
I suggest that we do not use the full package.json install to build the documentation if the application does not need any yarn dependencies for the dox specs to pass. The package.json should contain runtime depencencies and development dependencies, and arguably the aglio or redoc-cli used to build the documentation fits in neither of those groups.


#### Solution
Added a use_node input that defaults to true, similar to how it is done in the build workflow. This enables us to use node for runtime dependencies needed by the dox specs to successfully run. 
Added global install of redoc-cli to the publish_docs script. This way the publish_docs github action does not need to install all development dependencies, making it faster.

The changes are backwards compatible.
