### PR TITLE
Extend the build image to allow rails env overrides

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,11 +22,16 @@ on:
 
       # Set the ECS application service name
       ecs_app_service_name:
-        required: true
+        required: false
         type: string
 
       # Set the ECS sidekiq service name
       ecs_sidekiq_service_name:
+        required: false
+        type: string
+
+      # Override the rails environment otherwise parsed from the branch name
+      rails_env:
         required: false
         type: string
 
@@ -71,6 +76,7 @@ jobs:
           AWS_ECR_REPO_NAME: ${{ secrets.AWS_ECR_REPO_NAME }}
           AWS_ECS_CLUSTER_URL: ${{ secrets.AWS_ECS_CLUSTER_URL }}
           AWS_ECS_CLUSTER_NAME: ${{ secrets.AWS_ECS_CLUSTER_NAME }}
+          RAILS_ENV: ${{ inputs.rails_env }}
         run: bin/extract_params
 
       - name: Set up Docker Buildx
@@ -127,8 +133,17 @@ jobs:
                        ${{ steps.prep.outputs.tagged_image }}-test \
                      bin/test
 
+      - name: Store the new test cache
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-test
+          mv /tmp/.buildx-cache-test-new /tmp/.buildx-cache-test
+
+      ## Deploy steps
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1.5.11
+        if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         with:
           aws-access-key-id: ${{ secrets.AWS_IAM_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_IAM_ACCESS_SECRET_KEY }}
@@ -136,10 +151,12 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
+        if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Cache deploy image layers
         uses: actions/cache@v2
+        if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         with:
           path: /tmp/.buildx-cache-deploy
           key: docker-build-deploy-${{ github.sha }}
@@ -147,6 +164,7 @@ jobs:
 
       - name: Build deploy image
         uses: docker/build-push-action@v2
+        if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -170,16 +188,16 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-deploy-new
           # ! mode=max so all stages are exported
 
-      - name: Store the new cache
+      - name: Store the new deploy cache
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
+        if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         run: |
-          rm -rf /tmp/.buildx-cache-test
-          mv /tmp/.buildx-cache-test-new /tmp/.buildx-cache-test
           rm -rf /tmp/.buildx-cache-deploy
           mv /tmp/.buildx-cache-deploy-new /tmp/.buildx-cache-deploy
 
       - name: Deploy application to Amazon ECS
+        if: ${{ inputs.ecs_app_service_name != null }}
         env:
           ECS_CLUSTER_NAME: ${{ steps.prep.outputs.ecs_cluster_name }}
           APP_NAME: ${{ inputs.ecs_app_service_name }}

--- a/docker/extract_params
+++ b/docker/extract_params
@@ -2,16 +2,16 @@
 
 set -e
 
-rails_env=$(echo $GITHUB_REF_NAME | sed -e 's/master/production/g' -e 's/main/production/g')
-image_tag="git-$rails_env-$(echo $GITHUB_SHA | head -c7)"
+docker_env_tag=$(echo $GITHUB_REF_NAME | sed -e 's/master/production/g' -e 's/main/production/g')
+image_tag="git-$docker_env_tag-$(echo $GITHUB_SHA | head -c7)"
+rails_env=${RAILS_ENV:-${docker_env_tag}}
+default_ecs_cluster_name=${AWS_ECR_REPO_NAME}-${docker_env_tag}-cluster
 
 ruby_version=$(cat .ruby-version | tr -d '\r\n')
 bundler_version=$(ruby -e "require 'bundler'; puts Bundler::LockfileParser.bundled_with")
 node_version=$(cat .node-version | tr -d '\r\n')
 node_major="$(cut -d '.' -f 1 <<<"$node_version")"
 yarn_version=$(jq '.engines.yarn' package.json -r | tr -dc '[:alnum:].')
-
-default_ecs_cluster_name=${AWS_ECR_REPO_NAME}-${rails_env}-cluster
 
 echo ::set-output name=ruby_version::${ruby_version}
 echo ::set-output name=bundler_version::${bundler_version}
@@ -20,6 +20,6 @@ echo ::set-output name=node_major::${node_major}
 echo ::set-output name=yarn_version::${yarn_version}
 
 echo ::set-output name=tagged_image::${AWS_ECR_REPO_URL}/${AWS_ECR_REPO_NAME}:${image_tag}
-echo ::set-output name=deploy_tagged_image::${AWS_ECR_REPO_URL}/${AWS_ECR_REPO_NAME}:${rails_env}
+echo ::set-output name=deploy_tagged_image::${AWS_ECR_REPO_URL}/${AWS_ECR_REPO_NAME}:${docker_env_tag}
 
 echo ::set-output name=ecs_cluster_name::${AWS_ECS_CLUSTER_URL}/${AWS_ECS_CLUSTER_NAME:-${default_ecs_cluster_name}}


### PR DESCRIPTION
Task: NA

#### Aim
We might require different naming for the ecs environment from the environment we're using in rails and from the branch we're deploying from. 

#### Solution
Added rails_env option.
Also changed the workflow a bit so that we can use it only to test the
main branches without actual deploys.
