### PR TITLE
Fix the deploy image cache from test image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -184,7 +184,7 @@ jobs:
             app_secrets=.docker/application.yml
           cache-from: |
             type=local,src=/tmp/.buildx-cache-deploy
-            type=local,src=/tmp/.buildx-cache-test-new
+            type=local,src=/tmp/.buildx-cache-test
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-deploy-new
           # ! mode=max so all stages are exported
 


### PR DESCRIPTION
Task: NA

#### Aim
We "finalized" the test docker image before building the development image. We forgot to fix the cache-from declaration to take that into account.


