### PR TITLE
Update checkout action to v3

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -66,7 +66,7 @@ jobs:
         options: --name=postgres
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
 
       - name: Prepare image parameters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
       - name: Set up Ruby

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -107,7 +107,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
       - name: Set up Ruby


### PR DESCRIPTION
No task

#### Aim & Solution

Update `actions/checkout` to `v3` ([changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300)). Although it's a major version bump, there are no breaking changes for us.

