### PR TITLE
Feature/add_linux_platform_to_gemfile_lock

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -715,6 +715,9 @@ end
 ## Bundle install
 run 'bundle install'
 
+## Add linux to PLATFORMS to enable bundle install on CI
+run 'bundle lock --add-platform x86_64-linux'
+
 ## Initializes secrets_cli
 run 'bundle exec secrets init'
 


### PR DESCRIPTION
#### Aim
When creating a new app with rails 7 on a Mac, the Nokogiri is installed for the arm64-darwin architecture.
The Gemfile.lock looks like this:
```
...
nokogiri (1.13.6-arm64-darwin)
  racc (~> 1.4)
...

PLATFORMS
  arm64-darwin-21
``` 

This, in turn, fails the build when doing `bundle install` with the error:

> Your bundle only supports platforms ["arm64-darwin-21"] but your local platform is x86_64-linux. 
> Add the current platform to the lockfile with `bundle lock--add-platform x86_64-linux` and try again.

To make the builds pass, the `x86_64-linux` platform needs to be added to the Gemfile.lock as per instructions in the error.

#### Solution
Update template.rb with command to add linux platform to Gemfile.lock