### PR TITLE
Set timeout-minutes param for reusable workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -55,6 +55,7 @@ jobs:
   build_image:
     name: 'Build, Test, & Push Docker Image'
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
 
     services:
       postgres:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
   build:
     name: 'Build'
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
     env:
       BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
       RUBOCOP_CACHE_ROOT: .rubocop-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
     env:
       BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
     if: ${{ github.event_name == 'workflow_dispatch' && contains(inputs.deployers, format('@{0}', github.actor)) || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -83,6 +83,7 @@ jobs:
   publish_docs:
     name: 'Publish docs'
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
     env:
       BUNDLE_APP_CONFIG: ${{ inputs.bundle_app_config }}
     services:


### PR DESCRIPTION
No task

#### Aim

Lower default GA job timeout from 6 hours to 30 minutes. Recently, on one of our projects a job was stuck on `bundle install` step for 5 hours due to some unknown issue.

#### Solution

Set [`timeout-minutes`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) param on all jobs from reusable workflows to 30 minutes.

We'll modify this timeout if needed in the future.

