### PR TITLE
Update delete cache workflow timeout and concurrency

### DIFF
--- a/.github/workflows/delete-cache.yml
+++ b/.github/workflows/delete-cache.yml
@@ -1,9 +1,5 @@
 name: Delete Cache
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   workflow_call:
 
@@ -11,6 +7,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
No task

#### Problem

If you merge multiple PRs to master quickly, multiple delete-cache jobs will start, but all except the last one will be cancelled because of concurrency settings. Because of this some cache entries won't be deleted.

<img width="724" alt="image" src="https://user-images.githubusercontent.com/36794420/213681012-f57fcc85-adb2-4304-8a54-1b54b97d7cf0.png">

Also, timeout hasn't been configured for this workflow.

#### Solution

Remove concurrency settings so that all jobs run.

Add a 2-minute timeout to the workflow.




