### PR TITLE
Remove aptfile config from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,6 @@ on:
         type: boolean
         default: true
 
-      # Determines the path to the aptfile to select which apt packages get installed on the build runner
-      aptfile:
-        required: false
-        type: string
-
       # Sets BUNDLE_APP_CONFIG environment variable
       # See: https://bundler.io/man/bundle-config.1.html
       bundle_app_config:
@@ -73,7 +68,7 @@ on:
 
       # Additional environment variables set in the workflow
       # Format: JSON object with string values (key becomes env variable name, value becomes env variable value)
-      # Example: '{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }' 
+      # Example: '{ "FOO": "BAR", "BAZ": "${{ secrets.BAZ }}" }'
       ADDITIONAL_VARIABLES:
         required: false
 
@@ -119,19 +114,6 @@ jobs:
           key: ${{ runner.os }}-rubocop-cache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-rubocop-cache-
-      - name: Fetch Aptfile
-        if: ${{ startsWith(inputs.runner, 'ubuntu') && inputs.aptfile }}
-        id: apt_packages
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ${{ inputs.aptfile }}
-      - name: Install dependencies
-        if: ${{ startsWith(inputs.runner, 'ubuntu') && inputs.aptfile }}
-        run: |
-          sudo apt update
-          sudo apt install $aptfile
-        env:
-          aptfile: "${{ steps.apt_packages.outputs.content }}"
       - name: Set up Node
         uses: actions/setup-node@v2
         if: ${{ inputs.use_node }}


### PR DESCRIPTION
No task

Reverts changes added in https://github.com/infinum/default_rails_template/pull/132 and https://github.com/infinum/default_rails_template/pull/134.

We already expose a way to modify the CI to project's needs in the form of a `bin/prepare_ci` script and this is the preferred way to install additional libraries as it's much more flexible than adding specific steps to the workflow.

This is technically a breaking change, but the single project which used this feature already removed it so it's safe to merge.
