### PR TITLE
Use github context for REPO and BRANCH variables

### DIFF
--- a/.github/workflows/delete-cache.yml
+++ b/.github/workflows/delete-cache.yml
@@ -29,5 +29,5 @@ jobs:
           echo "Done"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ env.GITHUB_REPOSITORY }}
-          BRANCH: ${{ env.GITHUB_REF_NAME }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
No task.

Fix for https://github.com/infinum/default_rails_template/pull/140. Env variables now use the `github` context: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context.

