### PR TITLE
Use PR head ref for delete-cache workflow if available

### DIFF
--- a/.github/workflows/delete-cache.yml
+++ b/.github/workflows/delete-cache.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}


### PR DESCRIPTION
No task.

#### Aim

`delete-cache` workflow is triggered when a PR is merged or closed, and it uses `ref_name` from the `github` context (in a previous version it used the `GITHUB_REF_NAME` env variable, but that's the same thing) to delete cache for that branch. Unfortunately, `ref_name` returns the master branch and not the branch that was just merged, which caused the cache to be deleted on master whenever a PR was merged.

#### Solution

If in a pull request event, use `github.event.pull_request.head.ref` to fetch the name of the branch for the PR for which `delete-cache` was invoked. Otherwise, use `ref_name` (this is used when the workflow is triggered manually). 

This was tested on an internal project and is working correctly now.

