### PR TITLE
Use ref name instead of SHA for rubocop cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.RUBOCOP_CACHE_ROOT }}
-          key: ${{ runner.os }}-rubocop-cache-${{ github.sha }}
+          key: ${{ runner.os }}-rubocop-cache-${{ github.ref_name }}
           restore-keys: |
             ${{ runner.os }}-rubocop-cache-
       - name: Set up Node


### PR DESCRIPTION
No task

#### Aim & Solution

Use ref name (branch name) instead of latest branch SHA for rubocop cache key. This will ensure there's only a single rubocop cache entry per branch.

