### PR TITLE
Update reusable workflow actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -85,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache test image layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache-test
           key: docker-build-test-${{ github.sha }}
@@ -156,7 +156,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Cache deploy image layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ inputs.ecs_app_service_name != null || inputs.ecs_sidekiq_service_name != null }}
         with:
           path: /tmp/.buildx-cache-deploy

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -67,7 +67,7 @@ jobs:
         options: --name=postgres
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
 
       - name: Prepare image parameters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rubocop-cache-
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         if: ${{ inputs.use_node }}
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Prepare RuboCop cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.RUBOCOP_CACHE_ROOT }}
           key: ${{ runner.os }}-rubocop-cache-${{ github.sha }}
@@ -120,7 +120,7 @@ jobs:
         with:
           node-version-file: '.node-version'
       - name: Prepare node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ inputs.use_node }}
         with:
           path: node_modules

--- a/.github/workflows/delete-cache.yml
+++ b/.github/workflows/delete-cache.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
       - name: Set up Ruby

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         if: ${{ inputs.use_node }}
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           node-version-file: '.node-version'
       - name: Prepare node_modules cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ inputs.use_node }}
         with:
           path: node_modules

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -108,7 +108,7 @@ jobs:
             exit 1
           fi
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
       - name: Set up Ruby


### PR DESCRIPTION
No task.

#### Aim

Keep reusable workflows up to date.

#### Solution

Bump checkout to [v4](https://github.com/actions/checkout/releases/tag/v4.0.0). Default Node runtime was updated to v20, it shouldn't have an impact on our workflows.

Bump cache to [v3](https://github.com/actions/cache/releases/tag/v3.0.0). Minimum node version was updated from v12 to v16. It's a breaking change only for older runners, so it shouldn't impact us.

Bump setup-node to [v3](https://github.com/actions/setup-node/releases/tag/v3.0.0). Same change as for cache action.

