### PR TITLE
Task #905 - Add scan-licenses.yml GA workflow

### DIFF
--- a/.github/workflows/scan-licenses.yml
+++ b/.github/workflows/scan-licenses.yml
@@ -1,10 +1,15 @@
 name: Scan licenses
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 
 jobs:
   scanning:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: License scanning
     steps:
       - name: Git checkout

--- a/.github/workflows/scan-licenses.yml
+++ b/.github/workflows/scan-licenses.yml
@@ -1,0 +1,21 @@
+name: Scan licenses
+on:
+  workflow_call:
+
+jobs:
+  scanning:
+    runs-on: ubuntu-20.04
+    name: License scanning
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run license scanning
+        run: |
+          bundle config --local deployment false
+          bundle lock --add-platform x86_64-linux
+          bundle config --local deployment true
+          bundle exec license_finder

--- a/scan-licenses.yml
+++ b/scan-licenses.yml
@@ -1,11 +1,12 @@
 name: Scan licenses
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'Gemfile*'
       - 'package.json'
 
 jobs:
-  cleanup:
+  scanning:
     uses: infinum/default_rails_template/.github/workflows/scan-licenses.yml@v1

--- a/scan-licenses.yml
+++ b/scan-licenses.yml
@@ -1,0 +1,11 @@
+name: Scan licenses
+
+on:
+  push:
+    paths:
+      - 'Gemfile*'
+      - 'package.json'
+
+jobs:
+  cleanup:
+    uses: infinum/default_rails_template/.github/workflows/scan-licenses.yml@v1

--- a/template.rb
+++ b/template.rb
@@ -493,6 +493,7 @@ end
 
 get("#{BASE_URL}/build.yml", '.github/workflows/build.yml')
 get("#{BASE_URL}/delete-cache.yml", '.github/workflows/delete-cache.yml')
+get("#{BASE_URL}/scan-licenses.yml", '.github/workflows/scan-licenses.yml')
 
 ## Docker
 if no?('Will this application use Docker? [Yes]', :green)


### PR DESCRIPTION
Task: [#905](https://app.productive.io/1-infinum/time/me/task/5805311?tour=time-week-layout)

#### Aim
Add GA workflow that will run license scanning in the CI/CD pipeline for projects that already have configured license_finder gem.

#### Solution
Added scan-licenses.yml GA workflow that will be triggered when the Gemfile or package.json file has been changed.

First I tried to run license_finder only by using this command: `bundle exec license_finder` but I got some errors with missing nokogiri so I found this solution that includes adding x86_64-linux platform to the bundler. [License finder issue with this solution](https://github.com/pivotal/LicenseFinder/issues/828).
![Screenshot 2023-10-11 at 08 58 27](https://github.com/infinum/default_rails_template/assets/36743958/a9501cf3-5100-4e99-9f18-d271d17c33ef)
