### PR TITLE
Add `secrets pull -e development -y` to the `bin/prepare_ci` file

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -139,6 +139,9 @@ BIN_PREPARE_CI = <<~HEREDOC.strip_heredoc
   set -o pipefail
   set -o nounset
 
+  echo "=========== pull secrets ==========="
+  bundle exec secrets pull -e development -y
+
   # leaving it here as it's required by the GHA
 HEREDOC
 create_file 'bin/prepare_ci', BIN_PREPARE_CI, force: true

--- a/template.rb
+++ b/template.rb
@@ -141,8 +141,6 @@ BIN_PREPARE_CI = <<~HEREDOC.strip_heredoc
 
   echo "=========== pull secrets ==========="
   bundle exec secrets pull -e development -y
-
-  # leaving it here as it's required by the GHA
 HEREDOC
 create_file 'bin/prepare_ci', BIN_PREPARE_CI, force: true
 chmod 'bin/prepare_ci', 0755, verbose: false


### PR DESCRIPTION
Task: [#__TASK_NUMBER__](__ADD_URL_TO_PRODUCTIVE_TASK__)

#### Aim
During the onboarding project setup I faced the [CI build error](https://github.com/infinum/rails-onboarding-dmytro-pron-app/actions/runs/10772519324/job/29870333719), it happens because the 
CI task has no access to the project secrets. 

#### Solution
After investigation, the solution for my onboarding project was to add 
```
bundle exec secrets pull -e development -y
```
to the `bin/prepare_ci` file.
Since then the `bin/prepare_ci` file created from this repository, we can add
this line to the `template.rb`.

How to test:
- Create new rails app with this changed template file
```
rails new rails-onboarding-test --database=postgresql -T -B -m https://raw.githubusercontent.com/infinum/default_rails_template/fix/prepare-ci-file/template.rb
```
- Check that the `bin/prepare_ci` in the new app contains `bundle exec secrets pull -e development -y`