### PR TITLE
Update caching mechanism for RuboCop in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,12 +108,15 @@ jobs:
         with:
           bundler-cache: true
       - name: Prepare RuboCop cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('.ruby-version', '**/.rubocop.yml', 'Gemfile.lock') }}
         with:
           path: ${{ env.RUBOCOP_CACHE_ROOT }}
-          key: ${{ runner.os }}-rubocop-cache-${{ github.ref_name }}
+          key: rubocop-cache-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
           restore-keys: |
-            ${{ runner.os }}-rubocop-cache-
+            rubocop-cache-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name }}-
+            rubocop-cache-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-
       - name: Set up Node
         uses: actions/setup-node@v3
         if: ${{ inputs.use_node }}


### PR DESCRIPTION
Updates `actions/cache` from `v3` to `v4` ([there should be no breaking changes](https://github.com/actions/cache?tab=readme-ov-file#whats-new)).

Improves the cache key:
- invalidates the cache if Ruby version changes, Gemfile.lock changes, or any of project RuboCop configs change (see RuboCop's [Cache Validity](https://docs.rubocop.org/rubocop/usage/caching.html#cache-validity) section for more details)
- "updates" the cache on every run on default branch (master/main), to ensure other branches have up-to-date cache (see [this section](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache) for the technical details)

In practice:
- default branch will pull the latest cache from its branch, and "update" it when the workflow finishes
- other branches will pull the cache from its branch, or from the default branch if the workflow branch didn't yet save the cache, then save the cache **once** for that branch 