### PR TITLE
Remove `BundleAudit`, `Brakeman` and `ZeitwerkCheck` from overcommit hooks

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -397,12 +397,6 @@ CommitMsg:
     enabled: true
 
 PreCommit:
-  BundleAudit:
-    enabled: true
-    flags: ['--update']
-    on_warn: fail
-    command: ['bundle', 'exec', 'bundle-audit']
-
   BundleCheck:
     enabled: true
 
@@ -421,16 +415,6 @@ PreCommit:
 
   HardTabs:
     enabled: true
-
-PrePush:
-  Brakeman:
-    enabled: true
-    command: ['bundle', 'exec', 'brakeman']
-
-  ZeitwerkCheck:
-    enabled: true
-    description: 'Checks project structure for Zeitwerk compatibility'
-    command: ['bundle', 'exec', 'rails zeitwerk:check']
 HEREDOC
 create_file '.overcommit.yml', OVERCOMMIT_YML_FILE
 
@@ -492,29 +476,6 @@ updates:
 HEREDOC
 
 create_file '.github/dependabot.yml', DEPENDABOT_FILE
-
-# .git-hooks/pre_push/zeitwerk_check.rb
-ZEITWERK_CHECK_FILE = <<-HEREDOC.strip_heredoc
-# frozen_string_literal: true
-
-module Overcommit
-  module Hook
-    module PrePush
-      class ZeitwerkCheck < Base
-        def run
-          result = execute(command)
-          return :pass if result.success?
-
-          extract_messages result.stderr.split("\\n"),
-                           /^expected file (?<file>[[:alnum:]].*\.rb)/
-        end
-      end
-    end
-  end
-end
-HEREDOC
-
-create_file '.git-hooks/pre_push/zeitwerk_check.rb', ZEITWERK_CHECK_FILE
 
 # Ignore rubocop warnings in db/seeds.rb
 SEEDS_DISABLE_IGNORE = <<-HEREDOC.strip_heredoc


### PR DESCRIPTION
Removes some hooks from default overcommit config for a faster DX, without any value impact.

**BundleAudit**
Removed because:
- it already runs on CI (`bin/audit` script)
- dependabot automatically opens a PR to update vulnerable gems
- we have an internal monitoring tool to report CVEs
- we have people responsible for making sure CVEs get resolved

**Brakeman**
Removed because:
- it already runs on CI (`bin/audit` script)
- offenses are not that common, removing the overhead for every push is lower than the overhead of brakeman rarely failing on CI

**ZeitwerkCheck**
Removed because:
- it already runs on CI (`bin/lint` script)
- developers are expected to test their code locally, which would catch such errors before committing